### PR TITLE
batch size specified but never used

### DIFF
--- a/bin/scbasset_train.py
+++ b/bin/scbasset_train.py
@@ -80,7 +80,7 @@ def main():
              tf.TensorSpec(shape=(1344,4), dtype=tf.int8),
              tf.TensorSpec(shape=(n_cells), dtype=tf.int8),
         )
-    ).shuffle(2000, reshuffle_each_iteration=True).batch(128).prefetch(tf.data.AUTOTUNE)
+    ).shuffle(2000, reshuffle_each_iteration=True).batch(batch_size).prefetch(tf.data.AUTOTUNE)
     
     val_ds = tf.data.Dataset.from_generator(
         generator(val_data, m_val), 
@@ -88,7 +88,7 @@ def main():
              tf.TensorSpec(shape=(1344,4), dtype=tf.int8),
              tf.TensorSpec(shape=(n_cells), dtype=tf.int8),
         )
-    ).batch(128).prefetch(tf.data.AUTOTUNE)
+    ).batch(batch_size).prefetch(tf.data.AUTOTUNE)
     
     # build model
     model = make_model(bottleneck_size, n_cells)


### PR DESCRIPTION
Is the batch size fixed to 128 for some reason?

### Description of your changes
<!--- Changes proposed in this pull request -->

### Issue ticket number and link
<!--- Please include the JIRA ticket and link -->

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation add / update

### (If applicable) How has this been tested?
<!--- Please describe the tests that you ran to verify your changes. -->
<!--- Include details of your testing environment -->
